### PR TITLE
Limit placement radius

### DIFF
--- a/packages/backend/src/session/sessionManager.ts
+++ b/packages/backend/src/session/sessionManager.ts
@@ -206,6 +206,8 @@ export class SessionManager {
             tournament: params.tournament ?? null,
         });
 
+        this.logger.info(session);
+
         this.sessions.set(session.id, session);
 
         /*
@@ -487,6 +489,7 @@ export class SessionManager {
                 playerId,
                 x: cell.x,
                 y: cell.y,
+                placementRadius: session.gameOptions.placementRadius,
             });
         } catch (error: unknown) {
             if (error instanceof SimulationError || error instanceof GameTimeControlError) {

--- a/packages/backend/src/simulation/gameSimulation.ts
+++ b/packages/backend/src/simulation/gameSimulation.ts
@@ -11,6 +11,7 @@ type ApplyMoveParams = {
     playerId: string;
     x: number;
     y: number;
+    placementRadius: number;
 };
 
 type ApplyMoveResult = {

--- a/packages/shared/src/sharedTypes.ts
+++ b/packages/shared/src/sharedTypes.ts
@@ -106,6 +106,7 @@ export const zLobbyOptions = z.object({
     timeControl: zGameTimeControl,
     rated: z.boolean().default(false),
     firstPlayer: zLobbyFirstPlayer.default(`random`),
+    placementRadius: z.number().int().positive().default(PLACE_CELL_HEX_RADIUS),
 });
 export type LobbyOptions = z.infer<typeof zLobbyOptions>;
 
@@ -192,15 +193,15 @@ export function getHexDistance(a: HexCoordinate, b: HexCoordinate): number {
 }
 
 export function isCellWithinPlacementRadius(
-    placedCells: readonly HexCoordinate[],
+    cells: readonly HexCoordinate[],
     candidate: HexCoordinate,
     radius = PLACE_CELL_HEX_RADIUS,
 ): boolean {
-    if (placedCells.length === 0) {
+    if (cells.length === 0) {
         return true;
     }
 
-    return placedCells.some((cell) => getHexDistance(cell, candidate) <= radius);
+    return cells.some((cell) => getHexDistance(cell, candidate) <= radius);
 }
 
 export const zGameState = z.object({
@@ -261,6 +262,7 @@ export type ApplyGameMoveParams = {
     playerId: string;
     x: number;
     y: number;
+    placementRadius: number;
 };
 
 export type ApplyGameMoveResult = {
@@ -349,7 +351,7 @@ export function applyGameMove(gameState: GameState, params: ApplyGameMoveParams)
         throw new GameRuleError(`First placement must be at the origin`);
     }
 
-    if (!isCellWithinPlacementRadius(gameState.cells, { x, y })) {
+    if (!isCellWithinPlacementRadius(gameState.cells, { x, y }, params.placementRadius)) {
         throw new GameRuleError(`Cell must be within ${PLACE_CELL_HEX_RADIUS} hexes of an existing placed cell`);
     }
 


### PR DESCRIPTION
The objective is to stop the players from making small islands far away on the board, so I suggest limiting the radius to 1-2 cells, like this:
<img width="857" height="767" alt="image" src="https://github.com/user-attachments/assets/bf400df1-a066-429d-8bef-677e68193a3d" />
<img width="857" height="767" alt="image" src="https://github.com/user-attachments/assets/3262d80e-81dd-4a15-baa6-8f691750abce" />
I assume this could be an option when creating a game/lobby/sandbox/whatever
<br>

__What I've done__
Instead of fixing the max radius to 8
```js
export const PLACE_CELL_HEX_RADIUS = 8;
```
it now stores the placement radius in the LobbyOptions:
```js
export const zLobbyOptions = z.object({
    visibility: zLobbyVisibility,
    timeControl: zGameTimeControl,
    rated: z.boolean().default(false),
    firstPlayer: zLobbyFirstPlayer.default(`random`),
    placementRadius: z.number().int().positive().default(PLACE_CELL_HEX_RADIUS),
});
```
I also updated isCellWithinPlacementRadius and GameSimulation.applyMove accordingly 
<br>

Unfortunately, I couldn't get the backend to run for some reason, so I haven't been able to try it out. The frontend isn't implemented at the moment. It would also be nice to highlight the possible cells for the current player.