### PR TITLE
fix: preserve tournament match results

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,6 +7,7 @@
     "scripts": {
         "build": "vite build",
         "dev": "tsx --watch src/server.ts",
+        "test:session": "node --import tsx --test src/session/sessionManager.test.ts",
         "test:socket": "node --import tsx --test src/network/createSocketServer.test.ts",
         "test:tournament": "node --import tsx --test src/tournament/tournamentService.test.ts",
         "type-check": "tsc --noEmit",

--- a/packages/backend/src/network/createSocketServer.test.ts
+++ b/packages/backend/src/network/createSocketServer.test.ts
@@ -241,8 +241,8 @@ class FakeAuthService {
         return null;
     }
 
-    async getUserPreferences(): Promise<never> {
-        throw new Error(`not implemented`);
+    async getUserPreferences() {
+        return { allowSelfJoinCasualGames: false };
     }
 }
 
@@ -278,6 +278,7 @@ function createParticipant(id: string, displayName: string): FakePlayer {
 }
 
 function createFakeSession(sessionId: string, status: SessionInfo[`state`][`status`]): FakeSession {
+    const createdAt = 1_700_000_000_000;
     return {
         id: sessionId as SessionId,
         gameState: createEmptyGameState(),
@@ -300,7 +301,8 @@ function createFakeSession(sessionId: string, status: SessionInfo[`state`][`stat
         state: status === `in-game`
             ? {
                 status,
-                startedAt: 1_700_000_000_000,
+                createdAt,
+                startedAt: createdAt,
                 gameId: `${sessionId}-game`,
                 drawRequest: null,
                 drawRequestAvailableAfterTurn: 50,
@@ -308,6 +310,9 @@ function createFakeSession(sessionId: string, status: SessionInfo[`state`][`stat
             : status === `finished`
                 ? {
                     status,
+                    createdAt,
+                    startedAt: createdAt,
+                    finishedAt: createdAt + 1_000,
                     gameId: `${sessionId}-game`,
                     finishReason: `six-in-a-row`,
                     winningPlayerId: `${sessionId}-left`,
@@ -315,6 +320,7 @@ function createFakeSession(sessionId: string, status: SessionInfo[`state`][`stat
                 }
                 : {
                     status,
+                    createdAt,
                 },
     };
 }
@@ -539,24 +545,26 @@ test(`watch-session can follow multiple rooms and unwatch stops further updates`
     }
 });
 
-test(`watch-session rejects missing and non-live sessions`, async () => {
+test(`watch-session rejects missing sessions and allows non-live sessions`, async () => {
     const harness = await createHarness();
     try {
         harness.sessionManager.sessions.set(`lobby-1`, createFakeSession(`lobby-1`, `lobby`));
 
         const socket = await harness.connectSocket();
         try {
+            const missingErrorPromise = waitForEvent<{ sessionId: string; message: string }>(socket, `session-watch-error`);
             socket.emit(`watch-session`, { sessionId: `missing` });
-            const missingError = await waitForEvent<{ sessionId: string; message: string }>(socket, `session-watch-error`);
+            const missingError = await missingErrorPromise;
             assert.deepEqual(missingError, {
                 sessionId: `missing`,
                 message: `session unavailable`,
             });
 
+            const lobbyStartedPromise = waitForEvent<{ session: SessionInfo }>(socket, `session-watch-started`);
             socket.emit(`watch-session`, { sessionId: `lobby-1` });
-            const lobbyError = await waitForEvent<{ sessionId: string; message: string }>(socket, `session-watch-error`);
-            assert.equal(lobbyError.sessionId, `lobby-1`);
-            assert.equal(lobbyError.message, `session unavailable`);
+            const lobbyStarted = await lobbyStartedPromise;
+            assert.equal(lobbyStarted.session.id, `lobby-1`);
+            assert.equal(lobbyStarted.session.state.status, `lobby`);
         } finally {
             socket.close();
         }
@@ -565,7 +573,7 @@ test(`watch-session rejects missing and non-live sessions`, async () => {
     }
 });
 
-test(`watch-session enforces the four-session cap`, async () => {
+test(`watch-session supports more than four concurrent watched sessions`, async () => {
     const harness = await createHarness();
     try {
         const sessionIds = [`live-1`, `live-2`, `live-3`, `live-4`, `live-5`];
@@ -575,16 +583,12 @@ test(`watch-session enforces the four-session cap`, async () => {
 
         const socket = await harness.connectSocket();
         try {
-            for (const sessionId of sessionIds.slice(0, 4)) {
+            for (const sessionId of sessionIds) {
+                const startedPromise = waitForEvent<{ session: SessionInfo }>(socket, `session-watch-started`);
                 socket.emit(`watch-session`, { sessionId });
-                const started = await waitForEvent<{ session: SessionInfo }>(socket, `session-watch-started`);
+                const started = await startedPromise;
                 assert.equal(started.session.id, sessionId);
             }
-
-            socket.emit(`watch-session`, { sessionId: `live-5` });
-            const error = await waitForEvent<{ sessionId: string; message: string }>(socket, `session-watch-error`);
-            assert.equal(error.sessionId, `live-5`);
-            assert.equal(error.message, `You can only watch up to 4 live matches at once.`);
         } finally {
             socket.close();
         }
@@ -601,14 +605,16 @@ test(`watch-session does not consume the active join-session slot`, async () => 
 
         const socket = await harness.connectSocket();
         try {
+            const watchStartedPromise = waitForEvent(socket, `session-watch-started`);
             socket.emit(`watch-session`, { sessionId: `live-1` });
-            await waitForEvent(socket, `session-watch-started`);
+            await watchStartedPromise;
 
-            socket.emit(`join-session`, { sessionId: `lobby-1` });
-            const joined = await waitForEvent<{
+            const joinedPromise = waitForEvent<{
                 session: SessionInfo
                 participantRole: `player` | `spectator`
             }>(socket, `session-joined`);
+            socket.emit(`join-session`, { sessionId: `lobby-1` });
+            const joined = await joinedPromise;
 
             assert.equal(joined.session.id, `lobby-1`);
             assert.equal(joined.participantRole, `player`);

--- a/packages/backend/src/session/sessionManager.test.ts
+++ b/packages/backend/src/session/sessionManager.test.ts
@@ -1,0 +1,87 @@
+import 'reflect-metadata';
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { type SessionId } from '@ih3t/shared';
+import pino from 'pino';
+
+import { GameSimulation } from '../simulation/gameSimulation';
+import { GameTimeControlManager } from '../simulation/gameTimeControlManager';
+import { SessionManager } from './sessionManager';
+import { createGameSession, type ServerGameSession } from './types';
+
+class DelayedGameHistoryRepository {
+    private startResolver: () => void = () => {};
+    private releaseResolver: () => void = () => {};
+    readonly finishStarted = new Promise<void>((resolve) => {
+        this.startResolver = resolve;
+    });
+    private readonly releaseFinish = new Promise<void>((resolve) => {
+        this.releaseResolver = resolve;
+    });
+    finalized = false;
+
+    release(): void {
+        this.releaseResolver();
+    }
+
+    async finishGame(): Promise<void> {
+        this.startResolver();
+        await this.releaseFinish;
+        this.finalized = true;
+    }
+}
+
+function createSessionManager(gameHistoryRepository: DelayedGameHistoryRepository): SessionManager {
+    const serverShutdownService = {
+        createShutdownHook: () => ({ tryShutdown: () => {} }),
+    };
+    const metricsTracker = { track: () => {} };
+
+    return new SessionManager(
+        pino({ level: `silent` }),
+        serverShutdownService as never,
+        new GameSimulation(),
+        new GameTimeControlManager(),
+        {} as never,
+        gameHistoryRepository as never,
+        metricsTracker as never,
+        {} as never,
+    );
+}
+
+test(`finishing a session waits for its durable game result`, async () => {
+    const gameHistoryRepository = new DelayedGameHistoryRepository();
+    const sessionManager = createSessionManager(gameHistoryRepository);
+    const sessionId = `session-persistence` as SessionId;
+    const session = createGameSession(sessionId, {
+        visibility: `private`,
+        rated: false,
+        timeControl: { mode: `unlimited` },
+        firstPlayer: `host`,
+    });
+    session.state = `in-game`;
+    session.startedAt = Date.now() - 1_000;
+    session.gameId = `game-persistence`;
+
+    (sessionManager as unknown as {
+        sessions: Map<string, ServerGameSession>;
+    }).sessions.set(sessionId, session);
+
+    let finishResolved = false;
+    const finishPromise = sessionManager.terminateActiveSession(sessionId).then((result) => {
+        finishResolved = true;
+        return result;
+    });
+
+    await gameHistoryRepository.finishStarted;
+    await Promise.resolve();
+    assert.equal(finishResolved, false);
+
+    gameHistoryRepository.release();
+    const finishedSession = await finishPromise;
+
+    assert.equal(gameHistoryRepository.finalized, true);
+    assert.equal(finishedSession.state.status, `finished`);
+});

--- a/packages/backend/src/session/sessionManager.ts
+++ b/packages/backend/src/session/sessionManager.ts
@@ -931,11 +931,12 @@ export class SessionManager {
         await this.applyRatingAdjustments(session, winningPlayerId);
 
         const gameDurationMs = session.startedAt === null ? null : finishedAt - session.startedAt;
-        void this.ensureGameHistory(session).then((gameId) => this.gameHistoryRepository.finishGame(gameId, {
+        const gameId = await this.ensureGameHistory(session);
+        await this.gameHistoryRepository.finishGame(gameId, {
             winningPlayerId,
             durationMs: gameDurationMs,
             reason,
-        }));
+        });
 
         this.metricsTracker.track(`game-finished`, {
             sessionId: session.id,

--- a/packages/backend/src/tournament/tournamentService.test.ts
+++ b/packages/backend/src/tournament/tournamentService.test.ts
@@ -705,6 +705,62 @@ test(`single-elimination standings rank the third-place winner ahead of the lose
     assert.equal(fourthPlaceStanding?.rank, 4);
 });
 
+test(`elimination standings do not count automatic byes as match wins`, async () => {
+    const tournament = createTournament({
+        status: `completed`,
+        format: `single-elimination`,
+        completedAt: 200,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, status: `eliminated`, checkedInAt: 1, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, status: `completed`, checkedInAt: 2, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `completed`,
+                resultType: `bye`,
+                winnerProfileId: `player-1`,
+                resolvedAt: 100,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ displayName: `BYE`, isBye: true }),
+                ],
+            }),
+            createMatch({
+                id: `match-winners-2-1`,
+                bracket: `winners`,
+                round: 2,
+                order: 1,
+                state: `completed`,
+                bestOf: 3,
+                leftWins: 1,
+                rightWins: 2,
+                resultType: `played`,
+                winnerProfileId: `player-2`,
+                loserProfileId: `player-1`,
+                resolvedAt: 200,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+    });
+    const { service } = createService(tournament);
+
+    const detail = await service.getTournamentDetail(tournament.id, null);
+    const playerOne = detail?.standings.find((standing) => standing.profileId === `player-1`);
+    const playerTwo = detail?.standings.find((standing) => standing.profileId === `player-2`);
+
+    assert.equal(playerOne?.wins, 0);
+    assert.equal(playerOne?.losses, 1);
+    assert.equal(playerTwo?.wins, 1);
+    assert.equal(playerTwo?.losses, 0);
+});
+
 test(`listTournaments reports best placement for underfilled single-elimination champions`, async () => {
     const champion = createAccountUser({ id: `player-1`, username: `Champion` });
     const runnerUp = createAccountUser({ id: `player-2`, username: `Runner Up` });
@@ -1354,7 +1410,7 @@ test(`getTournamentDetail refreshes double-elimination participant statuses when
     assert.equal(runnerUp?.status, `eliminated`);
 });
 
-test(`getTournamentDetail repairs stale best-of session recovery without repeated updatedAt changes`, async () => {
+test(`getTournamentDetail retries missing best-of sessions before reopening the game`, async () => {
     const tournament = createTournament({
         status: `live`,
         format: `double-elimination`,
@@ -1406,6 +1462,16 @@ test(`getTournamentDetail repairs stale best-of session recovery without repeate
 
     await service.getTournamentDetail(tournament.id, null);
 
+    const awaitingRecovery = repository.getSync(tournament.id).matches[0]!;
+    assert.equal(awaitingRecovery.state, `in-progress`);
+    assert.equal(awaitingRecovery.sessionId, `missing-game-two-session`);
+
+    (service as unknown as {
+        missingSessionFirstSeenAt: Map<string, number>;
+    }).missingSessionFirstSeenAt.set(`missing-game-two-session`, Date.now() - 31_000);
+
+    await service.getTournamentDetail(tournament.id, null);
+
     const repaired = repository.getSync(tournament.id).matches[0]!;
     assert.equal(repaired.state, `ready`);
     assert.equal(repaired.sessionId, null);
@@ -1421,6 +1487,68 @@ test(`getTournamentDetail repairs stale best-of session recovery without repeate
 
     await service.getTournamentDetail(tournament.id, null);
     assert.equal(repository.getSync(tournament.id).updatedAt, recreated.updatedAt);
+});
+
+test(`reconciliation recovers a completed best-of game that appears after a persistence delay`, async () => {
+    const tournament = createTournament({
+        status: `live`,
+        format: `single-elimination`,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, checkedInAt: 1, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, checkedInAt: 2, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                bestOf: 3,
+                sessionId: `missing-game-two-session`,
+                startedAt: 100,
+                gameIds: [`game-1`],
+                currentGameNumber: 2,
+                leftWins: 1,
+                rightWins: 0,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+    });
+    const repository = new FakeTournamentRepository(tournament);
+    const gameHistoryRepository = new FakeGameHistoryRepository();
+    const { service } = createServiceWithOverrides({
+        repository,
+        gameHistoryRepository,
+    });
+
+    await service.reconcileAllTournaments();
+
+    let match = repository.getSync(tournament.id).matches[0]!;
+    assert.equal(match.state, `in-progress`);
+    assert.equal(match.sessionId, `missing-game-two-session`);
+
+    gameHistoryRepository.finishedGames.set(`game-2`, {
+        id: `game-2`,
+        sessionId: `missing-game-two-session`,
+        players: [
+            { playerId: `left-player`, profileId: `player-1` },
+            { playerId: `right-player`, profileId: `player-2` },
+        ],
+        gameResult: { winningPlayerId: `left-player` },
+    });
+
+    await service.reconcileAllTournaments();
+
+    match = repository.getSync(tournament.id).matches[0]!;
+    assert.equal(match.state, `completed`);
+    assert.equal(match.winnerProfileId, `player-1`);
+    assert.deepEqual(match.gameIds, [`game-1`, `game-2`]);
+    assert.equal(match.leftWins, 2);
+    assert.equal(match.rightWins, 0);
 });
 
 test(`roundDelayMinutes keeps the grand final pending until its cooldown expires`, async () => {

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -49,6 +49,7 @@ const kTournamentSystemClient: RequestClientInfo = {
 };
 
 const kClaimWinCountdownMs = 30_000;
+const kMissingSessionRecoveryGraceMs = 30_000;
 
 type ActiveClaimWin = {
     tournamentId: string;
@@ -401,7 +402,7 @@ function calculateEliminationStandings(tournament: TournamentRecord, activeParti
     for (const match of tournament.matches) {
         if (match.state !== `completed`) continue;
 
-        if (match.winnerProfileId) {
+        if (match.resultType !== `bye` && match.winnerProfileId) {
             winsByProfile.set(match.winnerProfileId, (winsByProfile.get(match.winnerProfileId) ?? 0) + 1);
         }
         if (match.loserProfileId) {
@@ -585,6 +586,7 @@ function toDetail(
 export class TournamentService {
     private readonly tournamentLocks = new Map<string, Mutex>();
     private readonly activeClaimWins = new Map<string, ActiveClaimWin>();
+    private readonly missingSessionFirstSeenAt = new Map<string, number>();
     private eventHandlers: TournamentServiceEventHandlers = {};
 
     constructor(
@@ -2006,6 +2008,7 @@ export class TournamentService {
         if (match.sessionId) {
             const session = this.sessionManager.getSessionInfo(match.sessionId);
             if (session) {
+                this.missingSessionFirstSeenAt.delete(match.sessionId);
                 if (session.state.status === `finished`) {
                     const winnerProfileId = this.resolveProfileIdFromFinishedSession(session, session.state.winningPlayerId);
                     if (!winnerProfileId) {
@@ -2034,8 +2037,13 @@ export class TournamentService {
                 return false;
             }
 
-            /* Session is gone — try to recover the result from game history */
-            const recoveredGame = await this.gameHistoryRepository.getFinishedGameBySessionId(match.sessionId)
+            /*
+             * Session state is in memory, while the finished game is persisted separately.
+             * Give that durable record time to become visible before abandoning the session
+             * reference; otherwise a transient persistence delay permanently loses the result.
+             */
+            const missingSessionId = match.sessionId;
+            const recoveredGame = await this.gameHistoryRepository.getFinishedGameBySessionId(missingSessionId)
                 ?? (match.gameIds.length > 0
                     ? await this.gameHistoryRepository.getFinishedGame(match.gameIds[match.gameIds.length - 1])
                     : null);
@@ -2044,11 +2052,23 @@ export class TournamentService {
                 if (winnerProfileId) {
                     const appliedGame = this.applyFinishedGameToMatch(tournament, match, recoveredGame.id, winnerProfileId);
                     if (appliedGame) {
+                        this.missingSessionFirstSeenAt.delete(missingSessionId);
                         return true;
                     }
                 }
             }
 
+            const now = Date.now();
+            const firstSeenAt = this.missingSessionFirstSeenAt.get(missingSessionId);
+            if (firstSeenAt === undefined) {
+                this.missingSessionFirstSeenAt.set(missingSessionId, now);
+                return false;
+            }
+            if (now - firstSeenAt < kMissingSessionRecoveryGraceMs) {
+                return false;
+            }
+
+            this.missingSessionFirstSeenAt.delete(missingSessionId);
             match.sessionId = null;
             match.state = `ready`;
             match.startedAt = null;


### PR DESCRIPTION
## Summary

- exclude automatic BYEs from elimination W-L records
- persist a finished game before exposing session completion
- retain missing session references for a short recovery window so delayed history writes can still resolve best-of games
- add regressions for the reported 1-2 standings case and delayed second-game recovery
- refresh stale socket tests to match the current unlimited/non-live watch behavior

Fixes #98
Fixes #99

## Verification

- pnpm --filter @ih3t/backend test:tournament (42 passed)
- pnpm --filter @ih3t/backend test:session (1 passed)
- pnpm --filter @ih3t/backend test:socket (5 passed)
- pnpm --filter @ih3t/backend type-check
- pnpm build:backend