### PR TITLE
fix: return 400 on a malformed json request body

### DIFF
--- a/packages/backend/src/network/createHttpApp.ts
+++ b/packages/backend/src/network/createHttpApp.ts
@@ -173,6 +173,13 @@ export class HttpApplication {
 
             const normalizedError = error instanceof Error ? error : new Error(`Unexpected server error`);
             setHttpErrorContext(res, { err: normalizedError });
+
+            if ((error as { type?: unknown }).type === `entity.parse.failed`) {
+                /* express.json() could not parse the body: the caller's mistake, not ours. */
+                res.status(400).json({ error: `Request body is not valid JSON.` });
+                return;
+            }
+
             res.status(500).json({ error: `Internal server error.` });
         });
 


### PR DESCRIPTION
A request body that `express.json()` cannot parse currently answers `500 Internal server error`.
It is the caller's mistake, so it is a `400` now:

```
$ curl -X POST /api/sessions -H 'Content-Type: application/json' -d '{"lobbyOptions":}'
before: 500 {"error":"Internal server error."}
after:  400 {"error":"Request body is not valid JSON."}
```

body-parser tags that error `type: 'entity.parse.failed'`; the final error handler checks for it before falling through to 500. 